### PR TITLE
Booking counter

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -152,19 +152,15 @@ class PageController extends Controller
         $tr = $this->showFormPost($userId, $pageId, true);
         $this->setEmbCsp($tr, $userId);
 
-        $hasActiveValidSession = false;
+        $isOutsideAdminly = $this->request->getParam("isOutsideAdminly");        
         
-        if($this->userSession->getUser()){
-            $hasActiveValidSession = $this->userSession->getUser()->getUid() == $userId;
-            if($hasActiveValidSession){
-                $numberOfSessions = (int) $this->c->getAppValue($this->appName, 'internalWidgetBookings');                
-                $this->c->setAppValue($this->appName, 'internalWidgetBookings', $numberOfSessions + 1);
-            }
-        }        
-        
-        if(!$hasActiveValidSession){
+        if($isOutsideAdminly == "true"){
             $numberOfSessions = (int) $this->c->getAppValue($this->appName, 'externalWidgetBookings');                
             $this->c->setAppValue($this->appName, 'externalWidgetBookings', $numberOfSessions + 1);
+        }
+        else{
+            $numberOfSessions = (int) $this->c->getAppValue($this->appName, 'internalWidgetBookings');                
+            $this->c->setAppValue($this->appName, 'internalWidgetBookings', $numberOfSessions + 1);
         }
 
         return $tr;

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -151,6 +151,22 @@ class PageController extends Controller
 
         $tr = $this->showFormPost($userId, $pageId, true);
         $this->setEmbCsp($tr, $userId);
+
+        $hasActiveValidSession = false;
+        
+        if($this->userSession->getUser()){
+            $hasActiveValidSession = $this->userSession->getUser()->getUid() == $userId;
+            if($hasActiveValidSession){
+                $numberOfSessions = (int) $this->c->getAppValue($this->appName, 'internalWidgetBookings');                
+                $this->c->setAppValue($this->appName, 'internalWidgetBookings', $numberOfSessions + 1);
+            }
+        }        
+        
+        if(!$hasActiveValidSession){
+            $numberOfSessions = (int) $this->c->getAppValue($this->appName, 'externalWidgetBookings');                
+            $this->c->setAppValue($this->appName, 'externalWidgetBookings', $numberOfSessions + 1);
+        }
+
         return $tr;
     }
 

--- a/src/form.js
+++ b/src/form.js
@@ -144,6 +144,16 @@
             lee = 1
         }
 
+        
+        el = document.getElementById('isOutsideAdminly')
+        if (el !== null && el.checked === false) {
+            var isOutsideAdminly = window.location.hostname !== window.parent.location.hostname;
+            el.value = isOutsideAdminly;
+            el.setAttribute("err", "err")
+            el.setAttribute("required", "1")
+            lee = 1
+        }
+
         if (lee !== 0) {
             e.preventDefault()
             e.stopPropagation()

--- a/templates/public/form.php
+++ b/templates/public/form.php
@@ -71,6 +71,7 @@ style('appointments', 'form');
             echo '</div>';
         }
         ?>
+        <input name="isOutsideAdminly" id="isOutsideAdminly" type="hidden">
         <button id="srgdev-ncfp_fbtn" <?php echo $disabled ?>class="primary srgdev-ncfp-form-btn" data-tr-ses-to="<?php
         echo htmlspecialchars($l->t('Session Timeout. Reload.'), ENT_QUOTES, 'UTF-8').'"><span>'.
             // TRANSLATORS This is the text for the "Book Now" button, on the appointment form.


### PR DESCRIPTION
### Changes

Writes to the app settings the amount of internal and external bookings

### Testing

Book new sessions from the dashboard and by using the external embed link in another browser or when you aren't logged in.
To see the updated counter more easily this can be tested in combination with https://github.com/MetaProvide/adminly_core/pull/116