### PR TITLE
Change notification priority for new talk rooms

### DIFF
--- a/lib/Backend/TalkIntegration.php
+++ b/lib/Backend/TalkIntegration.php
@@ -17,6 +17,7 @@ class TalkIntegration
     private array $tlk;
     private BackendUtils $utils;
     private \OCP\IConfig $config;
+	protected \OCA\Talk\Service\ParticipantService $participantService;
 
     /**
      * @param array $tlk
@@ -26,6 +27,7 @@ class TalkIntegration
         $this->utils = $utils;
         $this->tlk = $tlk;
         $this->config = \OC::$server->get(\OCP\IConfig::class);
+        $this->participantService = \OC::$server->get(\OCA\Talk\Service\ParticipantService::class);
     }
 
 

--- a/lib/Backend/TalkIntegration.php
+++ b/lib/Backend/TalkIntegration.php
@@ -89,8 +89,7 @@ class TalkIntegration
 
         $roomToken = $room->getToken();
 
-        $ps = \OC::$server->get(\OCA\Talk\Service\ParticipantService::class);
-        $participant = $ps->getSessionsAndParticipantsForRoom($room)[0];        
+        $participant = $this->participantService->getSessionsAndParticipantsForRoom($room)[0];        
         $this->participantService->updateNotificationLevel($participant, 1);
         
         $n = "getUs" . "erValue";

--- a/lib/Backend/TalkIntegration.php
+++ b/lib/Backend/TalkIntegration.php
@@ -87,6 +87,10 @@ class TalkIntegration
 
         $roomToken = $room->getToken();
 
+        $ps = \OC::$server->get(\OCA\Talk\Service\ParticipantService::class);
+        $participant = $ps->getSessionsAndParticipantsForRoom($room)[0];        
+        $this->participantService->updateNotificationLevel($participant, 1);
+        
         $n = "getUs" . "erValue";
         $hd = 'he' . "xdec";
         $c = $this->config->$n($userId, $this->appName, 'c' . "nk");


### PR DESCRIPTION
### Changes
Change notification priority for new talk rooms, so all new messages will be notified.

### Testing 

1. Book a new session via the appointments widget. 
2. Confirm it so a talk room is created. 
3. Check the notifications under the room settings and it should be set to All messages