### PR TITLE
Block duplicated slot on booking widget

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -1113,8 +1113,20 @@ class PageController extends Controller
         if (empty($out)) {
             $params['appt_state'] = '5';
         }
+        $slotsArray = explode(',',$out);
+        $slotsArrayUnique = [];
+        $slotsArrayTimestamps = [];
+        $i = 0;
 
-        $params['appt_sel_opts'] = $out;
+        foreach($slotsArray as $slot){
+            if (!in_array(substr($slot, 0,22), $slotsArrayTimestamps)) {
+                $slotsArrayTimestamps[$i] = substr($slot, 0,22);
+                $slotsArrayUnique[$i] = $slot;
+            }
+            $i++;
+        }
+
+        $params['appt_sel_opts'] = implode(',',$slotsArrayUnique);
 
         $params['appt_pps'] =
             BackendUtils::PSN_NWEEKS . ":" . $pps[BackendUtils::PSN_NWEEKS] . '.' .

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -1113,6 +1113,7 @@ class PageController extends Controller
         if (empty($out)) {
             $params['appt_state'] = '5';
         }
+
         $slotsArray = explode(',',$out);
         $slotsArrayUnique = [];
         $slotsArrayTimestamps = [];


### PR DESCRIPTION
### Changes

Removes slots that have the same date start and end timestamp from the date/time selector in the booking form

### Testing

Create 2 slots in the calendar with the same start and end time and date.
Open the booking form and you should be able to see only one of them.

### Screenshot

Before
![image](https://user-images.githubusercontent.com/29747887/196194717-2a59c67a-d185-4c16-988e-10b2c33e2c21.png)

### **After**
![image](https://user-images.githubusercontent.com/29747887/196193973-4cc57dbf-f1fd-477d-9d65-445bd475c390.png)

