### PR TITLE
Adds provider home timezone option

### DIFF
--- a/lib/Backend/DavListener.php
+++ b/lib/Backend/DavListener.php
@@ -24,6 +24,7 @@ use Psr\Log\LoggerInterface;
 use Sabre\VObject\Reader;
 use OCP\Activity\IManager as IActivityManager;
 use DateTime;
+use DateTimeZone;
 use OCA\Adminly_Clients\Db\ClientMapper;
 use OCA\Adminly_Clients\Db\Client;
 
@@ -302,8 +303,8 @@ class DavListener implements IEventListener
                     try {
                         $mailer->send($msg);
 
-                        $utz = $this->utils->getCalendarTimezone($userId, $config, $bc->getCalendarById($calId, $userId));
-
+                        $utz = new DateTimeZone($this->config->getUserValue($userId, $this->appName, "timezone", 'UTC'));
+                        
                         if (!isset($evt->DESCRIPTION)) $evt->add('DESCRIPTION');
                         $description = $evt->DESCRIPTION->getValue();
                         // TRANSLATORS Ex: Reminder sent on {{Date and Time}},
@@ -455,7 +456,7 @@ class DavListener implements IEventListener
 
 //        \OC::$server->getLogger()->error('DL Debug: M7');
 
-        $utz = $utils->getCalendarTimezone($userId, $config, $utils->transformCalInfo($calendarData));
+        $utz = new DateTimeZone($this->config->getUserValue($userId, $this->appName, "timezone", 'UTC'));
         try {
             $now = new \DateTime('now', $utz);
         } catch (\Exception $e) {

--- a/lib/Controller/StateController.php
+++ b/lib/Controller/StateController.php
@@ -307,6 +307,7 @@ class StateController extends Controller
             $calendarSettings = $this->utils->getUserSettings(BackendUtils::KEY_CLS, $this->userId);
             $d = $this->request->getParam("d");
             $prepTime = $this->request->getParam("prepTime");
+            $timezone = $this->request->getParam("timezone");
             if ($d !== null && strlen($d) < 512) {
                 if ($this->utils->setUserSettings(
                         BackendUtils::KEY_ORG,
@@ -319,10 +320,16 @@ class StateController extends Controller
                             BackendUtils::KEY_CLS,
                             $this->utils->getDefaultForKey(BackendUtils::KEY_CLS),
                             json_encode($calendarSettings), 'p0') === true) {
-                        $r->setStatus(200);
+                            $r->setStatus(200);
                         } else {
                             $r->setStatus(500);
                         }
+                        if($timezone !== null){                            
+		                    $this->config->setUserValue($this->userId, $this->appName, "timezone", $timezone);
+                            $r->setStatus(200);
+                            } else {
+                                $r->setStatus(500);
+                            }
                     }
                     else {
                         $r->setStatus(200);

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -63,6 +63,7 @@ class Personal implements ISettings
 		$prepTime = $this->appointmentsUtils->getUserSettings('calendar_settings', $this->userId)['prepTime'];
 		$publicPageUrl = $this->urlGenerator->getBaseUrl() . "/apps/appointments/pub/" . $formToken . "/form";
 		$embedPageUrl = $this->urlGenerator->getBaseUrl() . "/apps/appointments/embed/" . $formToken . "/form";
+		$timezone = $this->config->getUserValue($this->userId, $this->appName, "timezone", 'UTC');
 
 		//$lastSentReportTime = $this->config->getAppValue($this->appName, 'org-name', 0);
 		$parameters = [
@@ -71,7 +72,8 @@ class Personal implements ISettings
 			'phone' => $settings['phone'],
 			'email'=> $settings['email'],
 			'name'=> $settings['organization'],
-			'prepTime' => $prepTime
+			'prepTime' => $prepTime,
+			'timezone' => $timezone
 		];
 		return new TemplateResponse($this->appName, 'personal-settings', $parameters, '');
 	}

--- a/src/personalSettings.js
+++ b/src/personalSettings.js
@@ -75,6 +75,7 @@ document.getElementById("appointments-save-settings").onclick = function () {
   const phone = document.getElementById("phone");
   const email = document.getElementById("email");
   const prepTime = document.getElementById("prepTime");
+  const timezone = document.getElementById("timezoneSelector");
 
   const savedLabel = document.getElementById("saved");
 
@@ -106,6 +107,7 @@ document.getElementById("appointments-save-settings").onclick = function () {
       d: `{\"organization\":\"${name.value}\",\"email\":\"${email.value}\",\"address\":\" \",\"phone\":\"${phone.value}\",\"confirmedRdrUrl\":\"\",\"confirmedRdrId\":false,\"confirmedRdrData\":false}`,
       p: "p0",
       prepTime: prepTime.value,
+      timezone: timezone.value
     };
 
     $.post(OC.generateUrl("apps/appointments/state"), payload)

--- a/templates/personal-settings.php
+++ b/templates/personal-settings.php
@@ -67,17 +67,67 @@ style('appointments', 'settings'); // adds a CSS file
     </div>
     <div class="form-col">
         <select id="prepTime">
-            <option value="0" <?php if ($_['prepTime'] == "0") echo 'selected="selected"'; ?>>No lead time</option>
-            <option value="15" <?php if ($_['prepTime'] == "15") echo 'selected="selected"'; ?>>15 minutes</option>
-            <option value="30" <?php if ($_['prepTime'] == "30") echo 'selected="selected"'; ?>>30 minutes</option>
-            <option value="60" <?php if ($_['prepTime'] == "60") echo 'selected="selected"'; ?>>1 hour</option>
-            <option value="120" <?php if ($_['prepTime'] == "120") echo 'selected="selected"'; ?>>2 hours</option>
-            <option value="240" <?php if ($_['prepTime'] == "240") echo 'selected="selected"'; ?>>4 hours</option>
-            <option value="480" <?php if ($_['prepTime'] == "480") echo 'selected="selected"'; ?>>8 hours</option>
-            <option value="720" <?php if ($_['prepTime'] == "720") echo 'selected="selected"'; ?>>12 hours</option>
-            <option value="1440" <?php if ($_['prepTime'] == "1440") echo 'selected="selected"'; ?>>1 day</option>
-            <option value="2880" <?php if ($_['prepTime'] == "2880") echo 'selected="selected"'; ?>>2 days</option>
-            <option value="5760" <?php if ($_['prepTime'] == "5760") echo 'selected="selected"'; ?>>4 days</option>
+            <?php
+            $options = array(
+                0 => 'No lead time',
+                15 => '15 minutes',
+                30 => '30 minutes',
+                60 => '1 hour',
+                120 => '2 hours',
+                240 => '4 hours',
+                480 => '8 hours',
+                720 => '12 hours',
+                1440 => '1 day',
+                2880 => '2 days',
+                5760 => '4 days'
+            );
+
+            $selected = $_['prepTime'];
+
+            foreach ($options as $value => $label) {
+                $isSelected = ($value == $selected) ? 'selected' : '';
+                echo "<option value=\"$value\" $isSelected>$label</option>";
+            }
+            ?>
+        </select>
+    </div>
+
+    <div class="title-subtitle">
+        <h2>
+            Timezone for email confirmations
+        </h2>
+    </div>
+    <div class="form-col">
+        <select id="timezoneSelector">
+            <?php
+            $timezone_identifiers = DateTimeZone::listIdentifiers();
+            $continents = array();
+            foreach ($timezone_identifiers as $timezone_identifier) {
+                $exploded = explode('/', $timezone_identifier, 2);
+                if (count($exploded) == 2) {
+                    $continent = $exploded[0];
+                    $timezone = $exploded[1];
+                    if (!isset($continents[$continent])) {
+                        $continents[$continent] = array();
+                    }
+                    $continents[$continent][] = $timezone_identifier;
+                }
+            }
+            echo '<option value="UTC" ' . ($_['timezone'] == 'UTC' ? 'selected' : '') . '>UTC</option>';
+            ksort($continents);
+            foreach ($continents as $continent => $timezones) {
+                echo '<optgroup label="' . $continent . '">';
+                sort($timezones);
+                foreach ($timezones as $timezone_identifier) {
+                    $timezone = new DateTimeZone($timezone_identifier);
+                    $timezone_name = str_replace($continent . '/', '', $timezone_identifier);
+                    $timezone_name = str_replace('_', ' ', $timezone_name);
+                    $selected = $timezone_identifier == $_['timezone'] ? 'selected' : '';
+                    echo '<option value="' . $timezone_identifier . '" ' . $selected . '>' . $timezone_name . '</option>';
+                }
+                echo '</optgroup>';
+            }
+            ?>
         </select>
     </div>
 


### PR DESCRIPTION
### Changes

- Adds a timezone option in the settings page used as a base for email confirmations

### Testing

- Change the selected timezone and save it
- Book a new session
- The Timezone shown in the provider's email confirmation should be the same as the one set before

### Screenshot

![image](https://user-images.githubusercontent.com/29747887/229774867-7f040899-2c06-41fb-b512-b172f1b9416c.png)
