### PR TITLE
Add timezone to activity

### DIFF
--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -89,17 +89,23 @@ class Provider implements IProvider
 			$event->setIcon($this->url->getAbsoluteURL($this->url->imagePath('/custom_apps/appointments/', 'app-dark.svg')));
 		}
 
-		if ($event->getSubject() === self::SUBJECT_ADD) {
-			$subject = $this->l->t('{booking} has created a new booking for {dtStart}');
-		} elseif ($event->getSubject() === self::SUBJECT_CONFIRM) {
-			$subject = $this->l->t('{booking} has confirmed a booking for {dtStart}');
-		} elseif ($event->getSubject() === self::SUBJECT_CANCEL) {
-			$subject = $this->l->t('{booking} has cancelled a booking for {dtStart}');
-		} elseif ($event->getSubject() === self::SUBJECT_OTHER) {
-			$subject = $this->l->t('Booking for {booking} at {dtStart} has been modified');
-		} else {
-			throw new \InvalidArgumentException();
+		switch ($event->getSubject()) {
+			case self::SUBJECT_ADD:
+				$subject = $this->l->t('{booking} has created a new booking for {dtStart}');
+				break;
+			case self::SUBJECT_CONFIRM:
+				$subject = $this->l->t('{booking} has confirmed a booking for {dtStart}');
+				break;
+			case self::SUBJECT_CANCEL:
+				$subject = $this->l->t('{booking} has cancelled a booking for {dtStart}');
+				break;
+			case self::SUBJECT_OTHER:
+				$subject = $this->l->t('Booking for {booking} at {dtStart} has been modified');
+				break;
+			default:
+				throw new \InvalidArgumentException();
 		}
+		
 
 		$this->setSubjects($event, $subject, $subjectParameters);
 

--- a/lib/Backend/DavListener.php
+++ b/lib/Backend/DavListener.php
@@ -1280,7 +1280,7 @@ class DavListener implements IEventListener
 					'dtStart' => [
                         'type' => 'calendar',
                         'id' => $object['dtStart'],
-                        'name' =>  $dtStart->format('Y-m-d H:i T'),
+                        'name' =>  $dtStart->format('Y-m-d H:i e'),
                     ],				
                     'booking' => [
                         'type' => 'calendar-event',
@@ -1315,9 +1315,9 @@ class DavListener implements IEventListener
         }
 
         if ($componentType === 'VEVENT') {
-            return ['id' => (string) $component->UID, 'name' => (string) $component->SUMMARY, 'dtStart' => (string) $component->DTSTART, 'type' => 'event'];
+            return ['id' => (string) $component->UID, 'name' => (string) $component->SUMMARY, 'dtStart' => $component->DTSTART->getDateTime()->format('Y-m-d H:i e'), 'type' => 'event'];
         }
-        return ['id' => (string) $component->UID, 'name' => (string) $component->SUMMARY, 'dtStart' => (string) $component->DTSTART, 'type' => 'todo', 'status' => (string) $component->STATUS];
+        return ['id' => (string) $component->UID, 'name' => (string) $component->SUMMARY, 'dtStart' => $component->DTSTART->getDateTime()->format('Y-m-d H:i e'), 'type' => 'todo', 'status' => (string) $component->STATUS];
     }
 
     /**

--- a/lib/Backend/DavListener.php
+++ b/lib/Backend/DavListener.php
@@ -1280,7 +1280,7 @@ class DavListener implements IEventListener
 					'dtStart' => [
                         'type' => 'calendar',
                         'id' => $object['dtStart'],
-                        'name' =>  $dtStart->format('Y-m-d H:i'),
+                        'name' =>  $dtStart->format('Y-m-d H:i T'),
                     ],				
                     'booking' => [
                         'type' => 'calendar-event',


### PR DESCRIPTION
### Changes

Adds timezone identifier to the booking activities

### Testing 

Combined with https://github.com/MetaProvide/adminly_dashboard/pull/71, create a new booking
See the new booking on the newsfeed
Change the browser timezone to see the adjusted time